### PR TITLE
:sparkles: Describe commit message standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,48 @@ Welcome to the `Imtjl` organization on GitHub! We appreciate your interest in co
 ```
 &nbsp; &nbsp; └ [Managing repository on your local machine](https://github.com/Imtjl/GitHub-Tutorials/) 
 
+### Commit messages
+
+We use somewhat beautiful :sparkles: and outstanding :rocket: notation for commits!
+It would be familiar for those, who used conventional commits.
+
+Commit message should be in the following format:
+
+```
+type[!]: message
+```
+
+That is `type` optionally followed by exclamation mark, strictly followed by colon and ***one*** space, followed by a message. Total message length may exceed 80 characters (type is counted as one character), but it is recommended to make messages expressive and small.
+
+Type should be substituted with one of the following:
+
+- :sparkles:
+(`:sparkles:`) indicates new feature (analogue to `feat` tag in conventional commits)
+
+- :wrench:
+(`:wrench:`) improve or fix something (like somethis in between `refactor` and `fix` in conventional commits). Can be used interchangeably with :bug: (`:bug:`)
+
+
+- :bug:
+ (`:bug:`) Indicates bug fix! More like `fix` in conventional commits
+
+- :books:
+ (`:books:`) Denotes work on documentation (analogue is `doc` from conventional commits)
+
+- :hammer:
+ (`:hammer:`) General refactoring. Directory moves/additions/removals, project structure changes, work from ground up are all fall under this type
+
+- :recycle:
+  (`:recycle:`) same as :hammer: (`:hammer:`)
+
+- :rocket:
+ (`:rocket:`) Starting new great things (like new repository or subproject)!
+
+- :wastebasket:
+(`:wastebasket:`)
+ removing trash from repository like obsolete files
+
+
 ### Submitting Changes
 ```python
 1. Go to your forked repository on GitHub and create a pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,16 @@ It would be familiar for those, who used conventional commits.
 Commit message should be in the following format:
 
 ```
-type[!]: message
+type[!] message
 ```
 
-That is `type` optionally followed by exclamation mark, strictly followed by colon and ***one*** space, followed by a message. Total message length may exceed 80 characters (type is counted as one character), but it is recommended to make messages expressive and small.
+That is `type` optionally followed by exclamation mark, strictly followed by ***one*** space, followed by a message. 
 
-Type should be substituted with one of the following:
+Total message length may exceed 80 characters (type is counted as one character), but it is recommended to make messages expressive and small.
+
+Exclamation mark denotes breaking change. It is correlates with [`MAJOR`](https://semver.org/#summary) in Semantic Versioning. 
+
+Type should be one of the following:
 
 - :sparkles:
 (`:sparkles:`) indicates new feature (analogue to `feat` tag in conventional commits)
@@ -61,6 +65,15 @@ Type should be substituted with one of the following:
 (`:wastebasket:`)
  removing trash from repository like obsolete files
 
+#### Examples
+
+:bug: do not request auth token twice
+
+:sparkles: introduce commit message standard
+
+:books: document *that one* class
+
+:recycle: rework request handler
 
 ### Submitting Changes
 ```python


### PR DESCRIPTION
This PR defines our own commit message convention. It is important to keep conventions documented. Otherwise organisation participants and fellow strangers may get confused very soon.

I hope types are described as clear as possible and retains original intentions expressed by @worthant 